### PR TITLE
Prevent unit tests tree collapsing after a build

### DIFF
--- a/MonoDevelop.XUnit/MonoDevelop.UnitTesting.XUnit/NUnitAssemblyTestSuite.cs
+++ b/MonoDevelop.XUnit/MonoDevelop.UnitTesting.XUnit/NUnitAssemblyTestSuite.cs
@@ -55,6 +55,8 @@ namespace MonoDevelop.UnitTesting.XUnit
 		DateTime lastAssemblyTime;
 		XUnitExecutionSession session;
 
+		UnitTest[] oldList;
+
 		public XUnitAssemblyTestSuite(string name) : base(name)
 		{
 			cache = new XUnitTestInfoCache(this);
@@ -136,6 +138,11 @@ namespace MonoDevelop.UnitTesting.XUnit
 
 			lastAssemblyTime = GetAssemblyTime();
 
+			if (oldList != null) {
+				foreach (UnitTest t in oldList)
+					Tests.Add (t);
+			}
+
 			loader.AsyncLoadTestInfo(this, cache);
 		}
 
@@ -205,6 +212,9 @@ namespace MonoDevelop.UnitTesting.XUnit
 					test = new XUnitTestSuite(this, executor, child);
 				Tests.Add(test);
 			}
+
+			oldList = new UnitTest [Tests.Count];
+			Tests.CopyTo (oldList, 0);
 		}
 
 		protected override bool OnCanRun(IExecutionHandler executionContext)


### PR DESCRIPTION
Return the old cached tests when refreshing the tests after a build.
This prevents the unit tests tree from collapsing after each build.

Fixes #37
