### PR TITLE
Some fixes to robustify the addin

### DIFF
--- a/MonoDevelop.XUnit/MonoDevelop.UnitTesting.XUnit.csproj
+++ b/MonoDevelop.XUnit/MonoDevelop.UnitTesting.XUnit.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\MonoDevelop.Addins.0.3.6\build\net40\MonoDevelop.Addins.props" Condition="Exists('..\packages\MonoDevelop.Addins.0.3.6\build\net40\MonoDevelop.Addins.props')" />
+  <Import Project="..\packages\MonoDevelop.Addins.0.3.8\build\net40\MonoDevelop.Addins.props" Condition="Exists('..\packages\MonoDevelop.Addins.0.3.8\build\net40\MonoDevelop.Addins.props')" />
   <Import Project="..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -101,5 +101,5 @@
     <Folder Include="templates\" />
     <Folder Include="MonoDevelop.UnitTesting.XUnit\" />
   </ItemGroup>
-  <Import Project="..\packages\MonoDevelop.Addins.0.3.6\build\net40\MonoDevelop.Addins.targets" Condition="Exists('..\packages\MonoDevelop.Addins.0.3.6\build\net40\MonoDevelop.Addins.targets')" />
+  <Import Project="..\packages\MonoDevelop.Addins.0.3.8\build\net40\MonoDevelop.Addins.targets" Condition="Exists('..\packages\MonoDevelop.Addins.0.3.8\build\net40\MonoDevelop.Addins.targets')" />
 </Project>

--- a/MonoDevelop.XUnit/MonoDevelop.UnitTesting.XUnit/ExternalTestRunner.cs
+++ b/MonoDevelop.XUnit/MonoDevelop.UnitTesting.XUnit/ExternalTestRunner.cs
@@ -105,8 +105,12 @@ namespace MonoDevelop.UnitTesting.XUnit.External
 				Path = path,
 				SupportAssemblies = supportAssemblies.ToArray()
 			};
-
-			return (await connection.SendMessage(msg)).Result;
+			try {
+				return (await connection.SendMessage(msg)).Result;
+			} catch (Exception ex) {
+				LoggingService.LogError(ex.ToString ());
+				return new XUnitTestInfo();
+			}
 		}
 
 		[MessageHandler]

--- a/MonoDevelop.XUnit/MonoDevelop.UnitTesting.XUnit/NUnitAssemblyTestSuite.cs
+++ b/MonoDevelop.XUnit/MonoDevelop.UnitTesting.XUnit/NUnitAssemblyTestSuite.cs
@@ -232,20 +232,5 @@ namespace MonoDevelop.UnitTesting.XUnit
 			UpdateTests();
 			base.OnActiveConfigurationChanged();
 		}
-
-		public override void Dispose()
-		{
-			try
-			{
-				if (CachePath != null)
-				{
-					cache.WriteToDisk();
-				}
-			}
-			catch
-			{
-			}
-			base.Dispose();
-		}
 	}
 }

--- a/MonoDevelop.XUnit/Properties/Manifest.addin.xml
+++ b/MonoDevelop.XUnit/Properties/Manifest.addin.xml
@@ -27,7 +27,7 @@
 	<Extension path = "/MonoDevelop/UnitTesting/UnitTestMarkers">
 		<TestMarkers
 				testMethodAttributeMarker="Xunit.FactAttribute"
-				testCaseMethodAttributeMarker="XUnit.TheoryAttribute"
+				testCaseMethodAttributeMarker="Xunit.TheoryAttribute"
 			/>
 	</Extension>
 	

--- a/MonoDevelop.XUnit/Properties/Manifest.addin.xml
+++ b/MonoDevelop.XUnit/Properties/Manifest.addin.xml
@@ -25,10 +25,9 @@
 	</Extension>
 
 	<Extension path = "/MonoDevelop/UnitTesting/UnitTestMarkers">
-		<TestMarkers
-				testMethodAttributeMarker="Xunit.FactAttribute"
-				testCaseMethodAttributeMarker="Xunit.TheoryAttribute"
-			/>
+		<TestMarkers testMethodAttributeMarker="Xunit.FactAttribute"/>
+		<TestMarkers testMethodAttributeMarker="Xunit.TheoryAttribute"
+				testCaseMethodAttributeMarker="Xunit.InlineDataAttribute" />
 	</Extension>
 	
 </ExtensionModel>

--- a/MonoDevelop.XUnit/XUnitTestInfoCache.cs
+++ b/MonoDevelop.XUnit/XUnitTestInfoCache.cs
@@ -69,25 +69,6 @@ namespace MonoDevelop.XUnit
 			return null;
 		}
 
-		public void ReadFromDisk ()
-		{
-			using (var stream = new FileStream (testSuite.CachePath, FileMode.Open, FileAccess.Read)) {
-				var formatter = new BinaryFormatter ();
-				cachedTestInfo = (CachedTestInfo)formatter.Deserialize (stream);
-				modified = false;
-			}
-		}
-
-		public void WriteToDisk ()
-		{
-			if (modified && cachedTestInfo.TestInfo != null) {
-				using (var stream = new FileStream (testSuite.CachePath, FileMode.Create, FileAccess.Write)) {
-					var formatter = new BinaryFormatter ();
-					formatter.Serialize (stream, cachedTestInfo);
-				}
-			}
-		}
-
 		[Serializable]
 		class CachedTestInfo
 		{

--- a/MonoDevelop.XUnit/XUnitTestLoader.cs
+++ b/MonoDevelop.XUnit/XUnitTestLoader.cs
@@ -98,31 +98,10 @@ namespace MonoDevelop.XUnit
 				}
 
 				XUnitTestInfo testInfo;
-
 				try {
-					// If the information is cached in a file and it is up to date information,
-					// there is no need to parse again the assembly.
-
-					if (cache.Exists) {
-						cache.ReadFromDisk ();
-						testInfo = cache.GetTestInfo ();
-						if (testInfo != null) {
-							testSuite.OnTestSuiteLoaded (testInfo);
-							continue;
-						}
-					}
-
-#if EASY_DEBUGGING
 					var runner = new XUnitRunner.XUnitRunner();
 					testInfo = runner.GetTestInfo(testSuite.AssemblyPath, testSuite.SupportAssemblies.ToArray());
 					testSuite.OnTestSuiteLoaded(testInfo);
-#else
-					using (var runner = new ExternalTestRunner()) {
-						runner.Connect(XUnitVersion.XUnit2).Wait();
-						testInfo = runner.GetTestInfo(testSuite.AssemblyPath, testSuite.SupportAssemblies.ToList()).Result;
-						testSuite.OnTestSuiteLoaded(testInfo);
-					}
-#endif
 				} catch (Exception ex) {
 					LoggingService.LogError(ex.ToString());
 				}

--- a/MonoDevelop.XUnit/packages.config
+++ b/MonoDevelop.XUnit/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MonoDevelop.Addins" version="0.3.6" targetFramework="net45" />
+  <package id="MonoDevelop.Addins" version="0.3.8" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />

--- a/XUnitRunner/XUnitRunner.cs
+++ b/XUnitRunner/XUnitRunner.cs
@@ -109,15 +109,14 @@ namespace XUnitRunner
 
 			// if the test is the last element in the group
 			// then it's going to be a leaf node in the structure
-			if (count == 1) {
-				if (step == firstItem.NameParts.Length) {
-					testInfo.Id = firstItem.Id;
-					testInfo.Type = firstItem.Type;
-					testInfo.Method = firstItem.Method;
-					testInfo.Name = firstItem.DisplayName;
-					testInfo.Args = firstItem.Args;
-					return;
-				}
+			// we want add all test cases
+			if (count == 1 || step > firstItem.NameParts.Length - 1)  {
+				testInfo.Id = firstItem.Id;
+				testInfo.Type = firstItem.Type;
+				testInfo.Method = firstItem.Method;
+				testInfo.Name = firstItem.DisplayName;
+				testInfo.Args = firstItem.Args;
+				return;
 			}
 
 			// build the tree structure based on the parts of the name, so


### PR DESCRIPTION
Includes:
Bump MonoDevelop.Addins nuget to 0.3.8
Fixes NRE parsing unwanted data from shared libraries	
Adds multiple Inline test cases to the test tree	
Fixed wrong test tree recovered from file
Fixes wrong testCaseMethodAttributeMarker			
Fixes TestMarkers to work correctly with Fact and Theory markers